### PR TITLE
[Minor] Make `init public for direction custimization (i.e.,  not implemented)

### DIFF
--- a/Sources/CSS/Declaration.swift
+++ b/Sources/CSS/Declaration.swift
@@ -10,7 +10,7 @@ public struct Declaration: CSS {
     let value: String
     var code: String? = nil
     
-    init(property: CSSProperty, value: String) {
+    public init(property: CSSProperty, value: String) {
         self.property = property
         self.value = value
     }

--- a/Sources/CSS/Property.swift
+++ b/Sources/CSS/Property.swift
@@ -233,6 +233,8 @@ public enum CSSProperty: String, DashCaseConvertible {
     case richness
     case right
     case size
+    case scrollbarWidth
+    case scrollbarColor
     case speakHeader
     case speakNumeral
     case speakPunctuation


### PR DESCRIPTION
```Couldn't find a way to float items with default helpers. This open up access for direct customization.```
Hey there! Thanks for the works in this lib. Great stuff. Hopefully you find this useful, or, you find a way to incorporate the idea behind the change in a more expected way.

Sample:
```
function myFloat(_ side: Side) -> Declaration {
    Declaration(property: .float value: side.raw)
}
```