### PR TITLE
Remove unnecesary dependency on SwiftUI

### DIFF
--- a/Sources/CSS/CSS.swift
+++ b/Sources/CSS/CSS.swift
@@ -5,8 +5,6 @@
 //  Created by Carson Katri on 9/4/19.
 //
 
-import SwiftUI
-
 public protocol CSS {
     func string() -> String
 }


### PR DESCRIPTION
The SwiftUI dependency prevents the project to be used on linux.